### PR TITLE
Changeimport location of PROFILES_SERIALIZER

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -116,7 +116,7 @@ STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 )
 
-PROFILES_SERIALIZER = env("PROFILES_SERIALIZER", default="")
+PROFILES_SERIALIZER_MODULE, PROFILES_SERIALIZER = env("PROFILES_SERIALIZER", default="").rsplit(".", 1)
 
 # Configure this dictionary to have a mapping from database fieldnames to
 # human readable names. You might want to consider internationalizing

--- a/content/apps.py
+++ b/content/apps.py
@@ -1,18 +1,6 @@
-from importlib import import_module
-
 from django.apps import AppConfig
-from django.conf import settings
 
 
 class ContentConfig(AppConfig):
     name = "content"
     profiles_serializer = None
-
-    def ready(self):
-
-        module_ser_class = settings.PROFILES_SERIALIZER.rsplit(".", 1) or None
-        # raise Exception(module_ser_class)
-        if any(module_ser_class):
-            self.profiles_serializer = getattr(
-                import_module(module_ser_class[0]), module_ser_class[1]
-            )(many=True)

--- a/content/serializers.py
+++ b/content/serializers.py
@@ -1,4 +1,6 @@
-from django.apps import apps as django_apps
+from importlib import import_module
+
+from django.conf import settings
 from rest_framework import serializers
 
 from .models import TreeNode
@@ -6,7 +8,9 @@ from .models import TreeNode
 
 class TreeNodeSerializer(serializers.ModelSerializer):
 
-    profiles = django_apps.get_app_config("content").profiles_serializer
+    profiles = getattr(
+                import_module(settings.PROFILES_SERIALIZER_MODULE), settings.PROFILES_SERIALIZER
+            )(many=True)
     leaf_nodes = serializers.SerializerMethodField()
 
     class Meta:


### PR DESCRIPTION
Change import position for the generalized PROFILES_SERIALIZER.
We recognized that nested serialization does not work if the serializer is imported during ready()
method in AppConfig. However the correct behavior is achieved when importing
it inline in the TreeNodeSerializer.