### PR TITLE
Ordering

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = N806, N803, N802, I100, I101, I201, F401, F811, W503, E203, E501
+ignore = N806, N803, N802, I100, I101, I201, F401, F811, W503, E203, E501, E231
 exclude =
   manage.py
   sample_project/

--- a/sample_project/sample_content/models.py
+++ b/sample_project/sample_content/models.py
@@ -12,16 +12,34 @@ class MyProfile(BaseProfile):
         max_length=600,
         concat_choices=[
             [(None, "---------"), (1, 1), (2, 2), (3, 3), (4, 4)],
-            [(None, "---------"), ("Bonbon/s", "Bonbon/s"), ("Tüte/n Popcorn", "Tüte/n Popcorn"), ("Plätzchen", "Plätzchen"), ("Lutscher", "Lutscher")]
+            [
+                (None, "---------"),
+                ("Bonbon/s", "Bonbon/s"),
+                ("Tüte/n Popcorn", "Tüte/n Popcorn"),
+                ("Plätzchen", "Plätzchen"),
+                ("Lutscher", "Lutscher"),
+            ],
         ],
         seperators=[", ", " und "],
         default="",
-        blank=True
+        blank=True,
     )
     color = FromToConcatField(
         max_length=100,
-        from_choices=[(None, "---------"), ("blau", "blau"), ("grün", "grün"), ("gelb", "gelb"), ("rot", "rot")],
-        to_choices=[(None, "---------"), ("blau", "blau"), ("grün", "grün"), ("gelb", "gelb"), ("rot", "rot")],
+        from_choices=[
+            (None, "---------"),
+            ("blau", "blau"),
+            ("grün", "grün"),
+            ("gelb", "gelb"),
+            ("rot", "rot"),
+        ],
+        to_choices=[
+            (None, "---------"),
+            ("blau", "blau"),
+            ("grün", "grün"),
+            ("gelb", "gelb"),
+            ("rot", "rot"),
+        ],
         default="",
         blank=True,
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,10 @@
+[flake8]
+ignore = N806, N803, N802, I100, I101, I201, F401, F811, W503, E203, E501, E231
+omit =
+  manage.py
+  config/*
+  */migrations
+
 [tool:pytest]
 DJANGO_SETTINGS_MODULE= test_settings
 norecursedirs = *.egg .eggs dist build docs .tox .git __pycache__

--- a/solid_backend/glossary/views.py
+++ b/solid_backend/glossary/views.py
@@ -1,3 +1,4 @@
+from django.db.models import Prefetch
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from .models import GlossaryEntry
@@ -9,6 +10,8 @@ class GlossaryEntryEndpoint(ReadOnlyModelViewSet):
     Endpoint that provides the database table of all glossary entries.
     """
 
-    queryset = GlossaryEntry.objects.all()
+    queryset = GlossaryEntry.objects.order_by("term").prefetch_related(
+        Prefetch("links", queryset=GlossaryEntry.objects.order_by("term"))
+    )
     serializer_class = GlossaryEntrySerializer
     name = "glossaryentry"

--- a/solid_backend/quiz/admin.py
+++ b/solid_backend/quiz/admin.py
@@ -10,9 +10,7 @@ class QuizAnswerInline(admin.TabularInline):
 
 class QuizQuestionAdmin(admin.ModelAdmin):
     list_display = ["id", "text"]
-    inlines = [
-        QuizAnswerInline,
-    ]
+    inlines = [QuizAnswerInline]
 
 
 admin.site.register(QuizQuestion, QuizQuestionAdmin)

--- a/solid_backend/quiz/serializers.py
+++ b/solid_backend/quiz/serializers.py
@@ -1,34 +1,21 @@
 from rest_framework import serializers
 
 from solid_backend.photograph.serializers import PhotographSerializer
+from solid_backend.utils.serializers import DynamicExcludeModelSerializer
 
 from .models import QuizAnswer, QuizQuestion
 
 
-class QuizQuestionLessSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = QuizQuestion
-        fields = "__all__"
-
-
-class QuizAnswerLessSerializer(serializers.ModelSerializer):
+class QuizAnswerSerializer(DynamicExcludeModelSerializer):
     class Meta:
         model = QuizAnswer
         fields = "__all__"
 
 
 class QuizQuestionSerializer(serializers.ModelSerializer):
-    answers = QuizAnswerLessSerializer(many=True)
+    answers = QuizAnswerSerializer(exclude="question", many=True)
     img = PhotographSerializer(many=True)
 
     class Meta:
         model = QuizQuestion
-        fields = "__all__"
-
-
-class QuizAnswerSerializer(serializers.ModelSerializer):
-    question = QuizQuestionLessSerializer()
-
-    class Meta:
-        model = QuizAnswer
         fields = "__all__"

--- a/solid_backend/quiz/views.py
+++ b/solid_backend/quiz/views.py
@@ -16,7 +16,7 @@ class QuizQuestionEndpoint(ReadOnlyModelViewSet):
 
 class QuizAnswerEndpoint(ReadOnlyModelViewSet):
     """
-    Endpoint that provides the database table of all quiz answers including their related questions.
+    Endpoint that provides the database table of all quiz answers.
     """
 
     queryset = QuizAnswer.objects.all()

--- a/solid_backend/slideshow/admin.py
+++ b/solid_backend/slideshow/admin.py
@@ -47,16 +47,30 @@ admin.site.register(SlideshowPage, SlideshowPageAdmin)
 
 class SlideshowImageAdmin(admin.ModelAdmin):
     form = SlideshowAdminForm
-    list_display = ["id", "title", "show_page", "position", "img"]
+    list_display = [
+        "id",
+        "title",
+        "show_with_position",
+        "page_with_position",
+        "position",
+        "img",
+    ]
     list_display_links = ["title"]
     ordering = ["page__show__position", "page__position", "position"]
 
-    def show_page(self, obj):
-        return "{} : {}".format(
-            getattr(SlideshowPage.objects.get(id=obj.page.id), "show"), obj.page
-        )
+    def show_with_position(self, obj):
+        # Show field that is sortable by it's position
+        return "{} ({})".format(obj.page.show, obj.page.show.position)
 
-    show_page.short_description = "Show : Page"
+    show_with_position.short_description = "Show (position)"
+    show_with_position.admin_order_field = "page__show__position"
+
+    def page_with_position(self, obj):
+        # Page field that is sortable by it's position
+        return "{} ({})".format(obj.page, obj.page.position)
+
+    page_with_position.short_description = "Page (position)"
+    page_with_position.admin_order_field = "page__position"
 
 
 admin.site.register(SlideshowImage, SlideshowImageAdmin)

--- a/solid_backend/slideshow/admin.py
+++ b/solid_backend/slideshow/admin.py
@@ -29,10 +29,17 @@ admin.site.register(Slideshow, SlideshowAdmin)
 
 class SlideshowPageAdmin(admin.ModelAdmin):
     form = SlideshowAdminForm
-    list_display = ["id", "title", "show", "position"]
+    list_display = ["id", "title", "show_with_position", "position"]
     list_display_links = ["title"]
     inlines = [SlideshowImageInline]
     ordering = ["show__position", "position"]
+
+    def show_with_position(self, obj):
+        # Show field that is sortable by it's position
+        return "{} ({})".format(obj.show, obj.show.position)
+
+    show_with_position.short_description = "Show (position)"
+    show_with_position.admin_order_field = "show__position"
 
 
 admin.site.register(SlideshowPage, SlideshowPageAdmin)

--- a/solid_backend/slideshow/admin.py
+++ b/solid_backend/slideshow/admin.py
@@ -29,9 +29,10 @@ admin.site.register(Slideshow, SlideshowAdmin)
 
 class SlideshowPageAdmin(admin.ModelAdmin):
     form = SlideshowAdminForm
-    list_display = ["id", "title", "position", "show"]
+    list_display = ["id", "title", "show", "position"]
     list_display_links = ["title"]
     inlines = [SlideshowImageInline]
+    ordering = ["show__position", "position"]
 
 
 admin.site.register(SlideshowPage, SlideshowPageAdmin)

--- a/solid_backend/slideshow/admin.py
+++ b/solid_backend/slideshow/admin.py
@@ -40,8 +40,9 @@ admin.site.register(SlideshowPage, SlideshowPageAdmin)
 
 class SlideshowImageAdmin(admin.ModelAdmin):
     form = SlideshowAdminForm
-    list_display = ["id", "title", "position", "show_page", "img"]
+    list_display = ["id", "title", "show_page", "position", "img"]
     list_display_links = ["title"]
+    ordering = ["page__show__position", "page__position", "position"]
 
     def show_page(self, obj):
         return "{} : {}".format(

--- a/solid_backend/slideshow/serializers.py
+++ b/solid_backend/slideshow/serializers.py
@@ -28,4 +28,4 @@ class SlideshowSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Slideshow
-        fields = "__all__"
+        exclude = ["active"]

--- a/solid_backend/slideshow/serializers.py
+++ b/solid_backend/slideshow/serializers.py
@@ -1,46 +1,31 @@
 from rest_framework import serializers
 
 from solid_backend.photograph.serializers import PhotographSerializer
+from solid_backend.utils.serializers import DynamicExcludeModelSerializer
 
 from .models import Slideshow, SlideshowImage, SlideshowPage
 
 
-class SlideshowImageLessSerializer(serializers.ModelSerializer):
+class SlideshowImageSerializer(DynamicExcludeModelSerializer):
     img = PhotographSerializer()
 
     class Meta:
         model = SlideshowImage
-        fields = ["id", "position", "title", "img", "caption"]
+        fields = "__all__"
 
 
-class SlideshowPageLessSerializer(serializers.ModelSerializer):
-    images = SlideshowImageLessSerializer(many=True)
+class SlideshowPageSerializer(DynamicExcludeModelSerializer):
+    images = SlideshowImageSerializer(exclude="page", many=True)
 
     class Meta:
         model = SlideshowPage
-        fields = ["id", "position", "title", "text", "images"]
+        fields = "__all__"
 
 
 class SlideshowSerializer(serializers.ModelSerializer):
     img = PhotographSerializer()
-    pages = SlideshowPageLessSerializer(many=True)
+    pages = SlideshowPageSerializer(exclude="show", many=True)
 
     class Meta:
         model = Slideshow
-        fields = "__all__"
-
-
-class SlideshowPageSerializer(serializers.ModelSerializer):
-    images = SlideshowImageLessSerializer(many=True)
-
-    class Meta:
-        model = SlideshowPage
-        fields = "__all__"
-
-
-class SlideshowImageSerializer(serializers.ModelSerializer):
-    img = PhotographSerializer()
-
-    class Meta:
-        model = SlideshowImage
         fields = "__all__"

--- a/solid_backend/slideshow/views.py
+++ b/solid_backend/slideshow/views.py
@@ -34,10 +34,12 @@ class SlideshowEndpoint(ReadOnlyModelViewSet):
 
 class SlideshowPageEndpoint(ReadOnlyModelViewSet):
     """
-    Endpoint that provides the database table of all slideshow pages including their images.
+    Endpoint that provides the database table of all slideshow pages including their related images.
     """
 
-    queryset = SlideshowPage.objects.all()
+    queryset = SlideshowPage.objects.order_by("show", "position").prefetch_related(
+        Prefetch("images", queryset=SlideshowImage.objects.order_by("position"))
+    )
     serializer_class = SlideshowPageSerializer
     name = "slideshowpage"
 

--- a/solid_backend/slideshow/views.py
+++ b/solid_backend/slideshow/views.py
@@ -49,6 +49,6 @@ class SlideshowImageEndpoint(ReadOnlyModelViewSet):
     Endpoint that provides the database table of all slideshow images.
     """
 
-    queryset = SlideshowImage.objects.all()
+    queryset = SlideshowImage.objects.order_by("page", "position")
     serializer_class = SlideshowImageSerializer
     name = "slideshowimage"

--- a/solid_backend/utils/serializers.py
+++ b/solid_backend/utils/serializers.py
@@ -1,0 +1,19 @@
+from rest_framework import serializers
+
+
+class DynamicExcludeModelSerializer(serializers.ModelSerializer):
+    """
+    ModelSerializer that takes an additional 'exclude' argument with fields which should
+    not be displayed from the automatically generated fields.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Instantiate the superclass without the 'exclude' keyword argument
+        exclude = kwargs.pop("exclude", None)
+        super().__init__(*args, **kwargs)
+
+        # Exclude fields from serializer
+        if exclude is not None:
+            for field in set(self.fields):
+                if field in exclude:
+                    self.fields.pop(field)


### PR DESCRIPTION
- Der SlideshowEndpoint enthält nur noch aktive Slideshows-Objekte nach `position` angeordnet, sowie deren SlideshowPage-Objekte nach `position` angeordnet, sowie deren SlideshowImage-Objekte nach `position` angeordnet
- Im GlossaryEntryEndpoint sind die Objekte und deren Links alphabetisch angeordnet
- Im ProfilesEndpoint sind die zu einem Profil zugeordneten Photograph-Objekte nach `profile_position` angeordnet 