### PR TITLE
Filter search results for tree node id

### DIFF
--- a/solid_backend/content/views.py
+++ b/solid_backend/content/views.py
@@ -160,7 +160,9 @@ class IdListProfileEndpoint(ReadOnlyModelViewSet):
     filterset_fields = ["level", "parent"]
 
     @action(
-        detail=False, url_name="root", url_path="root",
+        detail=False,
+        url_name="root",
+        url_path="root",
     )
     def root(self, request, *args, **kwargs):
         queryset = TreeNode.objects.root_nodes()


### PR DESCRIPTION
For lazy loading it would be convenient to fetch all profiles that are attached to a certain tree node at once; that way when a tree node with profiles is expanded, all the linked data can be fetched and displayed. I expanded the existing endpoint to fetch all profiles so that it allows for a filter criterium "tree node id" in the url.